### PR TITLE
Fixing linux scripts to download the linux build & other fixes

### DIFF
--- a/Linux/LGSM/rustOxideUpdaterLGSM.sh
+++ b/Linux/LGSM/rustOxideUpdaterLGSM.sh
@@ -14,7 +14,7 @@ then
     ./rustserver mods-update >/dev/null 2>&1
     echo "Restarting the server..."
     ./rustserver restart >/dev/null 2>&1
-    echo "All operations completed successfully!"   
+    echo "All operations completed successfully!"
 else
     echo "No update is available"
 fi

--- a/Linux/NativeAuto/rustOxideUpdaterNative.sh
+++ b/Linux/NativeAuto/rustOxideUpdaterNative.sh
@@ -20,7 +20,7 @@ then
     echo "Updating Oxide..."
     curl -L "$oxideLatestURL" --output oxide.zip >/dev/null 2>&1
     unzip -o oxide.zip -d "$serverPath"/ >/dev/null 2>&1
-    rm oxide.zip >/dev/null 2>&1        
+    rm oxide.zip >/dev/null 2>&1
     echo "All operations completed successfully!"
 else
     echo "No update is available"

--- a/Linux/NativeAuto/rustOxideUpdaterNative.sh
+++ b/Linux/NativeAuto/rustOxideUpdaterNative.sh
@@ -8,7 +8,7 @@ steamcmdPath="/usr/games"
 # Edit above this line
 
 oxideVersionLatest=$(curl -s 'https://umod.org/games/rust/latest.json' | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
-oxideLatestURL=$(curl -s 'https://umod.org/games/rust/latest.json' | python3 -c "import sys, json; print(json.load(sys.stdin)['download_url'])")
+oxideLatestURL=$(curl -s 'https://umod.org/games/rust/latest.json' | python3 -c "import sys, json; print(json.load(sys.stdin)['snapshot_url'])")
 oxideVersionInstalled=$(cat oxide.version)
 echo "Checking for a new oxide version..."
 if [ "$oxideVersionLatest" != "$oxideVersionInstalled" ] || [ -z "$oxideVersionInstalled" ]

--- a/Linux/NativeManual/rustOxideUpdaterNativeManual.sh
+++ b/Linux/NativeManual/rustOxideUpdaterNativeManual.sh
@@ -32,18 +32,18 @@ then
             while : ; do
             read -n 2 k <&1
             echo
-            if [[ $k = "ok" ]] ; then   
+            if [[ $k = "ok" ]] ; then
             echo "All operations completed successfully!"
             break
-            else    
+            else
                 echo "Please restart the server and type 'ok' to continue"
-            fi 
+            fi
             done
         break
-    else    
+    else
         echo "Please stop the server and type 'done' to continue"
     fi
-    done  
+    done
 else
     echo "No update is available"
 fi

--- a/Linux/NativeManual/rustOxideUpdaterNativeManual.sh
+++ b/Linux/NativeManual/rustOxideUpdaterNativeManual.sh
@@ -8,7 +8,7 @@ steamcmdPath="/usr/games"
 # Edit above this line
 
 oxideVersionLatest=$(curl -s 'https://umod.org/games/rust/latest.json' | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
-oxideLatestURL=$(curl -s 'https://umod.org/games/rust/latest.json' | python3 -c "import sys, json; print(json.load(sys.stdin)['download_url'])")
+oxideLatestURL=$(curl -s 'https://umod.org/games/rust/latest.json' | python3 -c "import sys, json; print(json.load(sys.stdin)['snapshot_url'])")
 oxideVersionInstalled=$(cat oxide.version)
 echo "Checking for a new oxide version..."
 if [ "$oxideVersionLatest" != "$oxideVersionInstalled" ] || [ -z "$oxideVersionInstalled" ]

--- a/Linux/README.md
+++ b/Linux/README.md
@@ -8,13 +8,13 @@ The script comes in 3 variants:
 
 ## LGSM version (Strongly Recommended)
 
-This requires LGSM to be used for the server management. It requires no configuration for the script and it's the most 
+This requires LGSM to be used for the server management. It requires no configuration for the script and it's the most
 hassle-free option. Just put the script in the LGSM root directory, where the rustserver startup file is located. You can schedule this in a crontab.
 It will take care of everything.
 
 ## Linux Native Auto version
 
-This requires some configuration. 
+This requires some configuration.
 
 ```
 serverPath="/home/rustserver/serverfiles"
@@ -26,7 +26,7 @@ In order to put the script in a crontab, you also need to preceed it with a serv
 
 ## Linux Native Manual version
 
-Just like the other native option, this requires some configuration. 
+Just like the other native option, this requires some configuration.
 
 ```
 serverPath="/home/rustserver/serverfiles"

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -16,7 +16,7 @@ After you downloaded wget you will need to update it. Download wget.exe (Version
 Save the file at any directory with any name that is convenient for you but make sure you save it as a .bat file as this is for batch on Windows OS.
 
 ## Step 2 - Editing
-Right click and edit the file. 
+Right click and edit the file.
 
 ### wget
 After you installed wget, verify the directory of wget. If it is not at **"C:\Program Files (x86)\GnuWin32\bin"** please edit all lines that show **cd "C:\Program Files (x86)\GnuWin32\bin"** to show the correct directory of wget.

--- a/Windows/Update.bat
+++ b/Windows/Update.bat
@@ -73,10 +73,10 @@ pause
 cd "C:\Program Files (x86)\GnuWin32\bin"
 wget --no-check-certificate https://umod.org/games/rust/download -O "%ServerDirectory%Oxide.Rust.zip"
 wget --no-check-certificate https://umod.org/games/rust/latest.json -O "%ServerDirectory%installed.json"
-cd "C:\Program Files\7-Zip\" 
+cd "C:\Program Files\7-Zip\"
 7z x -spe "%ServerDirectory%Oxide.Rust.zip" -o"%ServerDirectory%" -aoa
-del "%ServerDirectory%Oxide.Rust.zip"  
+del "%ServerDirectory%Oxide.Rust.zip"
 echo "Rust, Oxide and installed.json has been updated"
 pause
 )
-exit  
+exit

--- a/Windows/Update.bat
+++ b/Windows/Update.bat
@@ -40,7 +40,7 @@ if '%1'=='ELEV' (del "%vbsGetPrivileges%" 1>nul 2>nul  &  shift /1)
 ::::::::::::::::::::::::::::
 ::START
 ::::::::::::::::::::::::::::
-REM Run shell as admin (example) - put here code as you like
+REM Run shell as admin [example] - put here code as you like
 ECHO %batchName% Arguments: %1 %2 %3 %4 %5 %6 %7 %8 %9
 echo "Starting . . ."
 set ServerDirectory=C:\rustcity\rust\


### PR DESCRIPTION
I noticed that for the Linux installers, it was set to `https://umod.org/games/rust/download` instead of `https://umod.org/games/rust/download/develop`.

https://umod.org/games/rust shows the first as being the Windows build and second as the Linux build. It might be their preferred setup to use the Linux archive for Linux servers.

I also replaced the parenthesis with a bracket since my syntax highlighting was showing something weird with it. Also all of the trailing spaces are removed now too.